### PR TITLE
Snowflake Generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 matrix:
   allow_failures:
     - go: master
+    - go: 1.8
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).

--- a/snowflakes/generator.go
+++ b/snowflakes/generator.go
@@ -1,0 +1,95 @@
+package snowflakes
+
+import (
+	"errors"
+	"github.com/osamingo/indigo/base58"
+	"sync"
+	"time"
+)
+
+const (
+	CounterLen  = 13
+	InstanceLen = 7
+	CounterMask = -1 ^ (-1 << CounterLen)
+)
+
+var (
+	ErrNoFuture    = errors.New("Start Time cannot be set in the future.")
+	ErrBadInstance = errors.New("Instance ID must be smaller than 129")
+)
+
+// Generator is a fountain for new snowflakes. StartTime must be
+// initialized to a past point in time and Instance ID can be any
+// positive value or 0.
+//
+// If any value is not correctly set, new IDs cannot be produced.
+type Generator struct {
+	StartTime  int64
+	InstanceID int8
+	mutex      *sync.Mutex
+	sequence   int32
+	now        int64
+}
+
+// NewID generates a new, unique snowflake value
+//
+// Up to 8192 snowflakes per second can be requested
+// If exhausted, it blocks and sleeps until a new second
+// of unix time starts.
+//
+// The return value is signed but always positive.
+//
+// Additionally, the return value is monotonic for a single
+// instance and weakly monotonic for many instances.
+func (g *Generator) NewID() (int64, error) {
+	if g.mutex == nil {
+		g.mutex = new(sync.Mutex)
+	}
+	if g.StartTime > time.Now().Unix() {
+		return 0, ErrNoFuture
+	}
+	if g.InstanceID < 0 {
+		return 0, ErrBadInstance
+	}
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+
+	var (
+		now   int64
+		flake int64
+	)
+	now = int64(time.Now().Unix())
+
+	if now == g.now {
+		g.sequence = (g.sequence + 1) & CounterMask
+		if g.sequence == 0 {
+			for now <= g.now {
+				now = int64(time.Now().Unix())
+				time.Sleep(time.Microsecond * 100)
+			}
+		}
+	} else {
+		g.sequence = 0
+	}
+
+	g.now = now
+
+	flake = int64(
+		((now - g.StartTime) << (InstanceLen + CounterLen)) |
+			(int64(g.sequence) << (InstanceLen)) |
+			(int64(g.InstanceID)))
+
+	return flake, nil
+}
+
+// IDtoEncoded encodes an incoming ID to a Base58 string
+func IDtoEncoded(id int64) string {
+	return base58.StdEncoding.Encode(uint64(id))
+}
+
+// EncodedToID will attempt to encode a string using Base58 and return
+// the ID
+func EncodedToID(idStr string) (int64, error) {
+	id, err := base58.StdEncoding.Decode(idStr)
+	return int64(id), err
+}

--- a/snowflakes/generator.go
+++ b/snowflakes/generator.go
@@ -82,8 +82,8 @@ func (g *Generator) NewID() (int64, error) {
 	return flake, nil
 }
 
-// IDtoEncoded encodes an incoming ID to a Base58 string
-func IDtoEncoded(id int64) string {
+// IDToEncoded encodes an incoming ID to a Base58 string
+func IDToEncoded(id int64) string {
 	return base58.StdEncoding.Encode(uint64(id))
 }
 

--- a/snowflakes/generator_test.go
+++ b/snowflakes/generator_test.go
@@ -1,0 +1,65 @@
+package snowflakes
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGenerator_NewID(t *testing.T) {
+	assert := assert.New(t)
+	generator := Generator{
+		StartTime:  time.Date(1998, time.November, 19, 0, 0, 0, 0, time.UTC).Unix(),
+		InstanceID: 18,
+	}
+
+	id, err := generator.NewID()
+	assert.NoError(err)
+	assert.True(id > 0)
+
+	lastId := id
+	for i := 0; i < 30000; i++ {
+		id, err := generator.NewID()
+		assert.NoError(err)
+		assert.True(id > lastId)
+		lastId = id
+	}
+
+	generator.InstanceID = -2
+
+	_, err = generator.NewID()
+	assert.Error(err)
+	assert.Equal(err, ErrBadInstance)
+
+	generator.StartTime = time.Now().Unix() + 10000
+
+	_, err = generator.NewID()
+	assert.Error(err)
+	assert.Equal(err, ErrNoFuture)
+}
+
+func BenchmarkGenerator_NewID(b *testing.B) {
+	generator := Generator{
+		StartTime:  time.Date(1998, time.November, 19, 0, 0, 0, 0, time.UTC).Unix(),
+		InstanceID: 18,
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		generator.NewID()
+	}
+}
+
+func TestEncodedToID(t *testing.T) {
+	assert := assert.New(t)
+
+	id, err := EncodedToID("JVzh")
+	assert.NoError(err)
+	assert.EqualValues(3414442, id)
+}
+
+func TestIDtoEncoded(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.EqualValues("JVzh", IDtoEncoded(3414442))
+}

--- a/snowflakes/generator_test.go
+++ b/snowflakes/generator_test.go
@@ -56,7 +56,7 @@ func TestEncodedToID(t *testing.T) {
 	assert.EqualValues(3414442, id)
 }
 
-func TestIDtoEncoded(t *testing.T) {
+func TestIDToEncoded(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.EqualValues("JVzh", IDToEncoded(3414442))

--- a/snowflakes/generator_test.go
+++ b/snowflakes/generator_test.go
@@ -28,13 +28,11 @@ func TestGenerator_NewID(t *testing.T) {
 	generator.InstanceID = -2
 
 	_, err = generator.NewID()
-	assert.Error(err)
 	assert.Equal(err, ErrBadInstance)
 
 	generator.StartTime = time.Now().Unix() + 10000
 
 	_, err = generator.NewID()
-	assert.Error(err)
 	assert.Equal(err, ErrNoFuture)
 }
 
@@ -61,5 +59,5 @@ func TestEncodedToID(t *testing.T) {
 func TestIDtoEncoded(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.EqualValues("JVzh", IDtoEncoded(3414442))
+	assert.EqualValues("JVzh", IDToEncoded(3414442))
 }


### PR DESCRIPTION
This PR merges the snowflake generator.

It includes a decoder and encoder for Base58.

Internally all new objects should use such a snowflake in form a int64 while externall the Base58 form should be used as it's more compact.

See [the taiga entry](https://tree.taiga.io/project/z3ta-arke/us/9?kanban-status=1046219) for details on the implementation